### PR TITLE
fixed android manifest

### DIFF
--- a/platforms/android/AndroidManifest.xml
+++ b/platforms/android/AndroidManifest.xml
@@ -1,5 +1,7 @@
-
-<manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    android:versionCode="1"
+    android:versionName="1.0" >
+	
 	<uses-permission android:name="android.permission.GET_ACCOUNTS" />
 	<uses-permission android:name="android.permission.WAKE_LOCK" />
 	<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />


### PR DESCRIPTION
The android build system is brand new and it takes on the responsibility of merging the plugin assets, instead of the CLI ( including the AndroidManifest.xml ).This means that in the AndroidManifest.xml, a certain structure should be kept in order for the merging in the build phase to go smoothly.

@yyosifov 
