### PR TITLE
message as first argument, whole object as second

### DIFF
--- a/native-src/android/src/com/telerik/pushplugin/PushPlugin.java
+++ b/native-src/android/src/com/telerik/pushplugin/PushPlugin.java
@@ -4,6 +4,10 @@ import android.content.Context;
 import android.os.Bundle;
 import android.util.Log;
 import com.google.android.gms.gcm.GcmListenerService;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Set;
 
 /**
  * Push plugin extends the GCM Listener Service and has to be registered in the AndroidManifest
@@ -79,7 +83,18 @@ public class PushPlugin extends GcmListenerService {
     public static void executeOnMessageReceivedCallback(Bundle data) {
         if (onMessageReceivedCallback != null) {
             Log.d(TAG, "Sending message to client: " + data.getString("message"));
-            onMessageReceivedCallback.success(data.getString("message"), data);
+            JSONObject dataAsJson = new JSONObject();
+            Set<String> keys = data.keySet();
+            for (String key : keys) {
+                try {
+                    // json.put(key, bundle.get(key)); see edit below
+                    dataAsJson.put(key, JSONObject.wrap(data.get(key)));
+                } catch(JSONException e) {
+//                    Log.d(TAG, "Error thrown: ", e.toStringu());
+                    //Handle exception here
+                }
+            }
+            onMessageReceivedCallback.success(data.getString("message"), dataAsJson.toString());
         } else {
             Log.d(TAG, "No callback function - caching the data for later retrieval.");
             cachedData = data;

--- a/native-src/android/src/com/telerik/pushplugin/PushPlugin.java
+++ b/native-src/android/src/com/telerik/pushplugin/PushPlugin.java
@@ -79,7 +79,7 @@ public class PushPlugin extends GcmListenerService {
     public static void executeOnMessageReceivedCallback(Bundle data) {
         if (onMessageReceivedCallback != null) {
             Log.d(TAG, "Sending message to client: " + data.getString("message"));
-            onMessageReceivedCallback.success(data.getString("message"));
+            onMessageReceivedCallback.success(data.getString("message"), data);
         } else {
             Log.d(TAG, "No callback function - caching the data for later retrieval.");
             cachedData = data;

--- a/native-src/android/src/com/telerik/pushplugin/PushPluginListener.java
+++ b/native-src/android/src/com/telerik/pushplugin/PushPluginListener.java
@@ -8,9 +8,11 @@ public interface PushPluginListener {
      * Defines a success callback method, which is used to pass success function reference
      * from the nativescript to the Java plugin
      *
+     * @param message
      * @param data
      */
-    void success(Object data);
+    void success(Object message, Object data);
+    void success(Object message); // method overload to mimic optional argument
 
 
     /**


### PR DESCRIPTION
It seems like a good idea to read out other things then just the message. Backwards compatibility is ensured by still sending the message as a first parameter.

In these examples: https://developers.google.com/cloud-messaging/downstream#receiving-messages-on-an-android-client-app 
it would seem that that is the intention of the message.

I'm not quite sure if this will work though, because I couldn't find a 'how-to-contribute' kind of page. So I'm not sure how to build the `.jar` that's a part of the npm package.

Let me know what you think of this change.