### PR TITLE
Plamen5kov/replace npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,5 @@
       "ios": "1.0.0",
       "android": "1.0.0"
     }
-  },
-  "dependencies": {
-    "nativescript-plugin-google-play-services": "26.0.2"
   }
 }

--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -1,0 +1,11 @@
+android { 
+    productFlavors {
+        "push-plugin" {
+            dimension "push-plugin"
+        }
+    }
+}
+
+dependencies {
+	compile 'com.google.android.gms:play-services:8.4.0'
+}


### PR DESCRIPTION
* replaced npm dependency to google play services with gradle  compile dependency to the library
* user will have to update `Google Repository` from the Android SDK manager, from `Extras/Google Repository` so gradle build can use it at build time.

ping: @twistedSynapse 