### PR TITLE
Depend only on gcm API from play-services. Updated version to 0.0.14.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 { 
   "name" : "nativescript-push-notifications",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "main" : "push-plugin.js",
   "repository": {
     "type": "git",

--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -7,5 +7,5 @@ android {
 }
 
 dependencies {
-	compile 'com.google.android.gms:play-services:8.4.0'
+	compile 'com.google.android.gms:play-services-gcm:8.4.0'
 }


### PR DESCRIPTION
This fixes the problem with exceeded number of methods ([issue](https://github.com/NativeScript/nativescript-cli/issues/1434)).