### PR TITLE
Update gradle to compile against the latest GCM SDK available

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 { 
   "name" : "nativescript-push-notifications",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "main" : "push-plugin.js",
   "repository": {
     "type": "git",

--- a/platforms/android/include.gradle
+++ b/platforms/android/include.gradle
@@ -7,5 +7,5 @@ android {
 }
 
 dependencies {
-	compile 'com.google.android.gms:play-services-gcm:8.4.0'
+	compile 'com.google.android.gms:play-services-gcm:+'
 }


### PR DESCRIPTION
This PR fixes: 

- Add compatibility with other plugins using the Google Play Services SDK #29 
- Run-time exception on Android when NS 2.3 and Android Build Tools 24 are used #40