### PR TITLE
Supporting webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 { 
   "name" : "nativescript-push-notifications",
   "version": "0.0.19",
-  "main" : "push-plugin.js",
+  "main" : "push-plugin",
   "repository": {
     "type": "git",
     "url": "https://github.com/NativeScript/push-plugin.git"


### PR DESCRIPTION
In order to be a webpack-discoverable module, we need to remove the `.js` suffix in the package.json `main` attribute. This allows webpack to correctly look for `my-module.android.js` or `my-module.ios.js`.

Details here:
http://docs.nativescript.org/angular/tooling/bundling-with-webpack.html#referencing-platform-specific-modules-from-packagejson