### PR TITLE
add a method that shows how to read data from notifications on resume

### DIFF
--- a/demo/app/app.ts
+++ b/demo/app/app.ts
@@ -7,6 +7,26 @@ purpose of the file is to pass control to the app’s first module.
 import "./bundle-config";
 import * as app from 'tns-core-modules/application';
 
+// ANDROID ONLY!
+// this event is used to handle notifications that have been received while the app is not in the foreground
+// in iOS the system invokes the notificationCallbackIOS method automatically when a notification is tapped
+app.on(app.resumeEvent, function(args) {
+    if (args.android) {
+        const act = args.android;
+        const intent = act.getIntent();
+        const extras = intent.getExtras();
+        if (extras) {
+            console.log("If your notification has data (key: value) pairs, they will be listed here:");
+            const keys = extras.keySet();
+            const iterator = keys.iterator();
+            while (iterator.hasNext()) {
+                const key = iterator.next();
+                console.log(key + ": " + extras.get(key).toString());
+            }
+        }
+    }
+});
+
 app.start({ moduleName: 'main-page' });
 
 /*


### PR DESCRIPTION
The demo should show how to handle Android data notifications received while app is in the background. 
Note that the notification data will only be available if the notification is tapped to open the app. If the notification is dismissed and the app is opened by tapping the app icon, no notification data will be available.
