### PR TITLE
docs: add development workflow and update scripts

### DIFF
--- a/DevelopmentWorkflow.md
+++ b/DevelopmentWorkflow.md
@@ -4,6 +4,8 @@
 
 - [Prerequisites](#prerequisites)
 - [Develop locally](#develop-locally)
+- [Build the plugin](#build-the-plugin)
+- [Testing the plugin](#testing-the-plugin)
 
 <!-- /TOC -->
 

--- a/DevelopmentWorkflow.md
+++ b/DevelopmentWorkflow.md
@@ -1,0 +1,66 @@
+# Development Workflow
+
+<!-- TOC depthFrom:2 -->
+
+- [Prerequisites](#prerequisites)
+- [Develop locally](#develop-locally)
+
+<!-- /TOC -->
+
+## Prerequisites
+
+- Install your native toolchain and NativeScript as [described in the docs](https://docs.nativescript.org/start/quick-setup)
+
+- Review [NativeScript plugins documentation](https://docs.nativescript.org/plugins/plugins) for more details on plugins development
+
+## Develop locally
+
+For local development we recommend using the npm commands provided in the plugin's package.json
+
+To run and develop using TypeScript demo:
+
+```bash
+# Go to demo directory
+cd nativescript-camera/demo
+# Build the plugin. This compiles all TypeScript files in the plugin directory, which is referenced in the demo's package.json
+npm run build.plugin
+# Install demo dependencies
+npm i
+# Run the demo for iOS or Android.
+tns run ios
+tns run android
+```
+
+After all the changes are done make sure to test them in all the demo app.
+
+Available npm commands from the plugin source directory:
+
+- `build` - builds the plugin so it can be used in the demo app.
+- `tslint` - check plugin's TypeScript sources for linting errors.
+- `clean` - clean the demo and plugin directories and build the plugin.
+
+## Build the plugin
+
+In order to build the native projects in the `native-src` directory, you need to have Xcode for the ios native project and Java or Android Studio for the Gradle build of the Android native project. Note that this is not required if you don't plan to update the native code - prebuilt binaries for iOS and Android are included in the `src/platforms` directory.
+
+## Testing the plugin
+
+Before building and running the demo for the first time, you should change the application ID (set by default to `org.nativescript.ppTest`) in the `demo/package.json` file to match your application in Firebase and/or provision in iOS. For Android, you should also update the `demo/app/App_Resources/Android/app.gradle` file with the new application ID.
+
+- Android - make sure you have added your `google-services.json` file to the `demo/app/App_Resources/Android` directory and that you have updated the `demo/app/main-view-model.ts` file with the sender ID of from your Firebase configuration. After the demo app is started the console will show the registration token of the device. For example:
+
+        w7ycrQS0sU:APA91bHCAxiFqonJb77cc785txYZ_0nrWe_sLRZm_nG32h4lhaJhZw-mquBh0rlmaoRVQBhnRsWiMTOWOcbCzuvGCOVKo7UAxog8JEufQO-nOJo3C2cMpPsT9RfiZVgaDc2tK9ezRUf9
+
+    To test push notifications for the device, you can use the following web request:
+
+    curl -X POST --header "Authorization: key=<YOUR_SERVER_KEY_HERE>" --Header "Content-Type: application/json" https://fcm.googleapis.com/fcm/send -d "{\"notification\":{\"title\": \"My title\", \"text\": \"My text\", \"badge\": \"1\", \"sound\": \"default\"}, \"data\":{\"foo\":\"bar\"}, \"priority\": \"High\", \"to\": \"<YOUR_DEVICE_TOKEN_HERE>\"}"
+
+    where <YOUR_SERVER_KEY_HERE> is the Server key from the Firebase Cloud Messaging Settings page and <YOUR_DEVICE_TOKEN_HERE> is the token you copied from the console.
+
+- iOS - make sure that you are using the correct provisioning profile and app ID with enabled APNs. After the application is started the console will show the registration token for the device. For example:
+
+        7058206f33224ff472976d5a80a1c913b4133c5815cca829d2e4d92a82e1c3b6
+
+    To test push notifications for the device, you can use a third party app like [Pusher](https://github.com/noodlewerk/NWPusher). Open the app, load the correct push certificate and use the device ID from the console to send a message.
+
+For details on plugins development workflow, read [NativeScript plugins documentation](https://docs.nativescript.org/plugins/building-plugins#step-2-set-up-a-development-workflow) covering that topic.

--- a/DevelopmentWorkflow.md
+++ b/DevelopmentWorkflow.md
@@ -23,7 +23,7 @@ To run and develop using TypeScript demo:
 
 ```bash
 # Go to demo directory
-cd nativescript-camera/demo
+cd push-plugin/demo
 # Build the plugin. This compiles all TypeScript files in the plugin directory, which is referenced in the demo's package.json
 npm run build.plugin
 # Install demo dependencies

--- a/DevelopmentWorkflow.md
+++ b/DevelopmentWorkflow.md
@@ -39,7 +39,7 @@ Available npm commands from the plugin source directory:
 
 - `build` - builds the plugin so it can be used in the demo app.
 - `tslint` - check plugin's TypeScript sources for linting errors.
-- `clean` - clean the demo and plugin directories and build the plugin.
+- `clean` - clean the demo and plugin directories.
 
 ## Build the plugin
 

--- a/demo/package.json
+++ b/demo/package.json
@@ -16,7 +16,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "nativescript-push-notifications": "../publish/package/nativescript-push-notifications-1.1.0.tgz",
+    "nativescript-push-notifications": "../src",
     "nativescript-theme-core": "^1.0.4",
     "tns-core-modules": "^3.3.0"
   },

--- a/src/package.json
+++ b/src/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "build": "npm i && tsc",
     "tslint": "cd .. && tslint \"**/*.ts\" --config tslint.json --exclude \"**/node_modules/**\"",
-    "clean": "cd ../demo && rimraf hooks node_modules platforms && cd ../src && rimraf node_modules && npm run build",
+    "clean": "cd ../demo && rimraf hooks node_modules platforms && cd ../src && rimraf node_modules",
     "ci.tslint": "npm i && tslint '**/*.ts' --config ../tslint.json --exclude '**/node_modules/**'",
     "postinstall": "node scripts/postinstall.js",
     "preuninstall": "node scripts/preuninstall.js"

--- a/src/package.json
+++ b/src/package.json
@@ -29,16 +29,15 @@
     ]
   },
   "scripts": {
-    "tsc": "tsc -skipLibCheck",
-    "build": "npm i --ignore-scripts && tsc && cd ../publish && ./pack.sh",
+    "build": "npm i && tsc",
     "tslint": "cd .. && tslint \"**/*.ts\" --config tslint.json --exclude \"**/node_modules/**\"",
-    "clean": "cd ../demo && rimraf hooks node_modules platforms && cd ../src && rimraf node_modules && npm run plugin.link",
-    "ci.tslint": "npm i --ignore-scripts && tslint '**/*.ts' --config ../tslint.json --exclude '**/node_modules/**'",
+    "clean": "cd ../demo && rimraf hooks node_modules platforms && cd ../src && rimraf node_modules && npm run build",
+    "ci.tslint": "npm i && tslint '**/*.ts' --config ../tslint.json --exclude '**/node_modules/**'",
     "postinstall": "node scripts/postinstall.js",
     "preuninstall": "node scripts/preuninstall.js"
   },
   "dependencies": {
-    "nativescript-hook": "0.2.2"
+    "nativescript-hook": "^0.2.0"
   },
   "devDependencies": {
     "rimraf": "^2.6.2",

--- a/src/scripts/postinstall.js
+++ b/src/scripts/postinstall.js
@@ -1,7 +1,11 @@
 var path = require('path');
 var utils = require('../hooks/utils');
-var projDir = path.resolve(__dirname, '../../../');
-require('nativescript-hook')(path.resolve(__dirname, '../')).postinstall();
+var hook = require('nativescript-hook')(path.resolve(__dirname, '../'));
+var projDir = hook.findProjectDir();
 
-utils.checkForGoogleServicesJson(projDir, path.join(projDir, 'app', 'App_Resources'));
-utils.addOnPluginInstall(path.join(projDir, 'platforms'));
+hook.postinstall();
+
+if (projDir) {
+    utils.checkForGoogleServicesJson(projDir, path.join(projDir, 'app', 'App_Resources'));
+    utils.addOnPluginInstall(path.join(projDir, 'platforms'));
+}

--- a/src/scripts/preuninstall.js
+++ b/src/scripts/preuninstall.js
@@ -1,6 +1,10 @@
 var path = require('path');
 var utils = require('../hooks/utils');
-var platformsDir = path.resolve(__dirname, '../../../platforms');
-require('nativescript-hook')(path.resolve(__dirname, '../')).preuninstall();
+var hook = require('nativescript-hook')(path.resolve(__dirname, '../'));
+var projDir = hook.findProjectDir();
 
-utils.removeIfPresent(platformsDir);
+hook.preuninstall();
+
+if (projDir) {
+    utils.removeIfPresent(path.join(projDir, 'platforms'));
+}


### PR DESCRIPTION
Updated to new version of nativescript-hook, which allows plugin to be referenced directly from demo app. No longer needed to pack a .tgz first.