### PR TITLE
fix: project build on android, ios background notifications

### DIFF
--- a/demo/app/App_Resources/Android/AndroidManifest.xml
+++ b/demo/app/App_Resources/Android/AndroidManifest.xml
@@ -11,7 +11,7 @@
 		android:xlargeScreens="true"/>
 
 	<uses-sdk
-		android:minSdkVersion="17"
+		android:minSdkVersion="19"
 		android:targetSdkVersion="__APILEVEL__"/>
 
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>

--- a/demo/package.json
+++ b/demo/package.json
@@ -29,7 +29,7 @@
     "nativescript-dev-typescript": "~0.6.0",
     "nativescript-dev-webpack": "~0.14.0",
     "tslint": "^5.8.0",
-    "typescript": "~2.7.2"
+    "typescript": "~2.8.1"
   },
   "scripts": {
     "build.plugin": "cd ../src && npm run build",

--- a/native-src/ios/PushPlugin/PushManager.m
+++ b/native-src/ios/PushPlugin/PushManager.m
@@ -148,13 +148,13 @@ static IMP handleActionWithIdentifierOriginalMethod = NULL;
         appState = application.applicationState;
     }
     
-    if (appState == UIApplicationStateActive) {
+    if (appState == UIApplicationStateActive || appState == UIApplicationStateBackground) {
         [Push sharedInstance].notificationMessage = userInfo;
-        [Push sharedInstance].isInline = YES;
-        [[Push sharedInstance] notificationReceived];        
+        [Push sharedInstance].isInline = appState == UIApplicationStateActive ;
+        [[Push sharedInstance] notificationReceived]; 
     } else {
         [Push sharedInstance].launchNotification = userInfo;
-    }
+    } 
 }
 
 - (void)my_application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {


### PR DESCRIPTION
Typescript version updated trying to fix issue with watcher clearing console logs
Android fix - minimum API version should be 19
iOS fix - related to https://github.com/NativeScript/push-plugin/issues/218